### PR TITLE
Upgrades to Rspec2 and removes curb dependency

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--colour
+--backtrace

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,3 @@
 source :gemcutter
 
-gem "rake", "0.8.7"
-gem "curb", "0.6.7"
-gem "nokogiri"
-gem "jeweler"
-gem "yard"
-
-group :test do
-  gem "rspec"
-end
+gemspec

--- a/calais.gemspec
+++ b/calais.gemspec
@@ -39,23 +39,10 @@ Gem::Specification.new do |s|
      "spec/helper.rb"
   ]
 
-  if s.respond_to? :specification_version then
-    current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
-    s.specification_version = 3
+  s.add_dependency("nokogiri", ">= 1.3.3")
+  s.add_dependency("json", ">= 1.1.3")
+  s.add_dependency("curb", ">= 0.1.4")
 
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<nokogiri>, [">= 1.3.3"])
-      s.add_runtime_dependency(%q<json>, [">= 1.1.3"])
-      s.add_runtime_dependency(%q<curb>, [">= 0.1.4"])
-    else
-      s.add_dependency(%q<nokogiri>, [">= 1.3.3"])
-      s.add_dependency(%q<json>, [">= 1.1.3"])
-      s.add_dependency(%q<curb>, [">= 0.1.4"])
-    end
-  else
-    s.add_dependency(%q<nokogiri>, [">= 1.3.3"])
-    s.add_dependency(%q<json>, [">= 1.1.3"])
-    s.add_dependency(%q<curb>, [">= 0.1.4"])
-  end
+  s.add_development_dependency("rspec", ">= 2.0.0")
 end
 

--- a/calais.gemspec
+++ b/calais.gemspec
@@ -41,7 +41,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency("nokogiri", ">= 1.3.3")
   s.add_dependency("json", ">= 1.1.3")
-  s.add_dependency("curb", ">= 0.1.4")
 
   s.add_development_dependency("rspec", ">= 2.0.0")
 end

--- a/lib/calais.rb
+++ b/lib/calais.rb
@@ -1,5 +1,6 @@
 require 'digest/sha1'
 require 'net/http'
+require 'uri'
 require 'cgi'
 require 'iconv'
 require 'set'
@@ -8,7 +9,6 @@ require 'date'
 require 'rubygems'
 require 'nokogiri'
 require 'json'
-require 'curb'
 
 if RUBY_VERSION.to_f < 1.9
   $KCODE = "UTF8"

--- a/spec/calais/client_spec.rb
+++ b/spec/calais/client_spec.rb
@@ -66,7 +66,7 @@ describe Calais::Client, :enlighten do
   it 'provides access to the enlighten command on the generic rest endpoint' do
     @client.should_receive(:do_request).with(anything).and_return(SAMPLE_RESPONSE)
     @client.enlighten
-    @client.instance_variable_get(:@client).url.should == Calais::REST_ENDPOINT
+    @client.url.should == URI.parse(Calais::REST_ENDPOINT)
   end
 
   it 'provides access to the enlighten command on the beta rest endpoint' do
@@ -74,6 +74,6 @@ describe Calais::Client, :enlighten do
 
     @client.should_receive(:do_request).with(anything).and_return(SAMPLE_RESPONSE)
     @client.enlighten
-    @client.instance_variable_get(:@client).url.should == Calais::BETA_REST_ENDPOINT
+    @client.url.should == URI.parse(Calais::BETA_REST_ENDPOINT)
   end
 end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,5 +1,5 @@
 require 'rubygems'
-require 'spec'
+require 'rspec'
 require 'yaml'
 
 require File.dirname(__FILE__) + '/../lib/calais'

--- a/spec/spec.opts
+++ b/spec/spec.opts
@@ -1,4 +1,0 @@
---colour
---format s
---backtrace
---loadby mtime


### PR DESCRIPTION
Needed to use your gem in JRuby environment and curb wouldn't build it's native extensions so I forked your repo and refactored to use the ruby core net/http library. I also upgraded it to use rspec 2 and modified the Gemfile and the gemspec to use bundler's gemspec method so the dependencies are only listed in one place.
