### PR TITLE
the iconv library is deprecated in ruby 1.9.3

### DIFF
--- a/lib/calais.rb
+++ b/lib/calais.rb
@@ -2,7 +2,6 @@ require 'digest/sha1'
 require 'net/http'
 require 'uri'
 require 'cgi'
-require 'iconv'
 require 'set'
 require 'date'
 

--- a/lib/calais.rb
+++ b/lib/calais.rb
@@ -2,6 +2,7 @@ require 'digest/sha1'
 require 'net/http'
 require 'uri'
 require 'cgi'
+require 'iconv' if RUBY_VERSION.to_f < 1.9
 require 'set'
 require 'date'
 

--- a/lib/calais/client.rb
+++ b/lib/calais/client.rb
@@ -23,7 +23,7 @@ module Calais
     def enlighten
       post_args = {
         "licenseID" => @license_id,
-        "content" => Iconv.iconv('UTF-8//IGNORE', 'UTF-8',  "#{@content} ").first[0..-2],
+        "content" => "#{@content} ".encode(Encoding::UTF_8, :invalid => :replace, :undef => :replace, :replace => '')[0 .. -2],
         "paramsXML" => params_xml
       }
 
@@ -33,37 +33,37 @@ module Calais
     def params_xml
       check_params
       document = Nokogiri::XML::Document.new
-      
+
       params_node = Nokogiri::XML::Node.new('c:params', document)
       params_node['xmlns:c'] = 'http://s.opencalais.com/1/pred/'
       params_node['xmlns:rdf'] = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
-      
+
       processing_node = Nokogiri::XML::Node.new('c:processingDirectives', document)
       processing_node['c:contentType'] = AVAILABLE_CONTENT_TYPES[@content_type] if @content_type
       processing_node['c:outputFormat'] = AVAILABLE_OUTPUT_FORMATS[@output_format] if @output_format
       processing_node['c:calculateRelevanceScore'] = 'false' if @calculate_relevance == false
       processing_node['c:reltagBaseURL'] = @reltag_base_url.to_s if @reltag_base_url
-      
+
       processing_node['c:enableMetadataType'] = @metadata_enables.join(',') unless @metadata_enables.empty?
       processing_node['c:docRDFaccessible'] = @store_rdf if @store_rdf
       processing_node['c:discardMetadata'] = @metadata_discards.join(';') unless @metadata_discards.empty?
       processing_node['c:omitOutputtingOriginalText'] = 'true' if @omit_outputting_original_text
-      
+
       user_node = Nokogiri::XML::Node.new('c:userDirectives', document)
       user_node['c:allowDistribution'] = @allow_distribution.to_s unless @allow_distribution.nil?
       user_node['c:allowSearch'] = @allow_search.to_s unless @allow_search.nil?
       user_node['c:externalID'] = @external_id.to_s if @external_id
       user_node['c:submitter'] = @submitter.to_s if @submitter
-      
+
       params_node << processing_node
       params_node << user_node
-      
+
       if @external_metadata
         external_node = Nokogiri::XML::Node.new('c:externalMetadata', document)
         external_node << @external_metadata
         params_node << external_node
       end
-      
+
       params_node.to_xml(:indent => 2)
     end
 

--- a/lib/calais/client.rb
+++ b/lib/calais/client.rb
@@ -23,7 +23,9 @@ module Calais
     def enlighten
       post_args = {
         "licenseID" => @license_id,
-        "content" => "#{@content} ".encode(Encoding::UTF_8, :invalid => :replace, :undef => :replace, :replace => '')[0 .. -2],
+        "content" => RUBY_VERSION.to_f < 1.9 ?
+          Iconv.iconv('UTF-8//IGNORE', 'UTF-8',  "#{@content} ").first[0..-2] :
+          "#{@content} ".encode(Encoding::UTF_8, :invalid => :replace, :undef => :replace, :replace => '')[0 .. -2],
         "paramsXML" => params_xml
       }
 


### PR DESCRIPTION
it prints a warning every time it comes across this:

``` ruby
require 'iconv'
```

iconv is only being used in one place in the calais gem, in Client#enlighten, to convert a string into valid utf-8, ignoring errors. i've migrated this to use ruby 1.9's String#encode, with a fallback to the original code in case the user is running ruby 1.8.

this has silenced the warning and is giving me the same behavior i had before. let me know if you'd like any other changes made to this before inclusion.

regards
